### PR TITLE
Remove dependency on Pluto

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.0.2"
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 PlutoCanvasPlot = "57876ffe-7b7d-4c51-befe-9eb7dc4baaca"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/PlutoVTKPlot.jl
+++ b/src/PlutoVTKPlot.jl
@@ -1,5 +1,4 @@
 module PlutoVTKPlot
-using Pluto
 using PlutoCanvasPlot
 using UUIDs
 using Colors


### PR DESCRIPTION
It is not necessary, because we access `PlutoRunner` from `Main`. If you would like to ensure that this package is only used inside Pluto, you would need something else, like:

```julia
if !isdefined(Main, :PlutoRunner)
	@warn "Oops"
end
```

Perhaps a better explanation: the `Pluto` package is the Pluto _server_, but the PlutoVTKPlot package will run inside a notebook process, and does not need the functionality of the Pluto server.